### PR TITLE
This pr fix the issue with pytthon and macos by using pythonw

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,8 +10,6 @@ fi
 
 if [[ $(uname) == Darwin ]]; then
 	echo 'export ${PREFIX}/bin:$PATH"' >> ~/.bash_profile
-	# export CC=${PREFIX}/bin/clang
-	# export CXX=${CC}++
 	export LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
 	export CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/c++/v1/"
 fi
@@ -38,6 +36,8 @@ if [[ $(uname) == Darwin ]]; then
 		  -Dwith-mpi=OFF \
 		  -Dwith-openmp=OFF \
 		  -Dwith-python=3 \
+		  -DPYTHON_EXECUTABLE=${PYTHON}\
+		  -DPYTHON_LIBRARY=${PREFIX}/lib/libpython${PY_VER}.dylib \
 		  -Dwith-gsl=${PREFIX} \
 		  -DREADLINE_ROOT_DIR=${PREFIX} \
 		  -DLTDL_ROOT_DIR=${PREFIX} \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
   number: 2
   skip: true  # [win]
   skip: true  # [py<30]
+  osx_is_app: True
 
 requirements:
   build:
@@ -44,6 +45,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - openmpi
     - python
+    - python.app # [osx]
     - readline
     - scipy
     - statsmodels

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - openmpi
     - python
-    - python.app # [osx]
+    - python.app  # [osx]
     - readline
     - scipy
     - statsmodels


### PR DESCRIPTION
Checklist
* [* ] Used a fork of the feedstock to propose changes
* [* ] Bumped the build number (if the version is unchanged)
* [* ] Reset the build number to `0` (if the version changed)
* [* ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [* ] Ensured the license file is being packaged.

python.app is installed now. On macos you have to use the framework build (pythonw) instead off the regular build (python).
See: https://matplotlib.org/faq/osx_framework.html

