### PR TITLE
Patch python 3.8.0 AttributeError: module 'cgi' has no attribute 'esc…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "nest-simulator" %}
 {% set version = "2.20.0" %}
 
-{% set build = 2 %}
+{% set build = 3 %}
 
 # mpi must be defined for conda-smithy lint
 {% set mpi = mpi or 'nompi' %}
@@ -18,6 +18,8 @@ package:
 source:
   url: https://github.com/nest/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 40e33187c22d6e843d80095b221fa7fd5ebe4dbc0116765a91fc5c425dd0eca4
+  patches:
+    - source/patches/changes_py38.patch
 
 build:
   number: {{ build }}

--- a/recipe/source/patches/changes_py38.patch
+++ b/recipe/source/patches/changes_py38.patch
@@ -1,0 +1,26 @@
+diff --git a/extras/help_generator/generate_help.py b/extras/help_generator/generate_help.py
+index 1a5b3bb67..833a2cf3a 100755
+--- a/extras/help_generator/generate_help.py
++++ b/extras/help_generator/generate_help.py
+@@ -29,11 +29,11 @@ The helpindex is built during installation in a separate step.
+ """
+ 
+ import os
++import html
+ import io
+ import re
+ import sys
+ import textwrap
+-import cgi
+ 
+ from writers import coll_data
+ from helpers import check_ifdef, create_helpdirs, cut_it
+@@ -132,7 +132,7 @@ for fname in allfiles:
+                     line = name_line_0 + ' ' + name_line_1
+                 line = textwrap.dedent(line).strip()
+                 # Tricks for the blanks
+-                line = cgi.escape(line)
++                line = html.escape(line)
+                 line = re.sub('^(\s)*- ', ' &bull; ', line)
+                 line = re.sub('^(\s)*@note', ' &bull; ', line)
+                 alllines.append(line)


### PR DESCRIPTION
Use `html.escape` instead of `cgi.escape`.