### PR TITLE
Fix compiler issues in run environment

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+source "${PREFIX}/bin/nest_vars.sh"
 
-source ${CONDA_PREFIX}/bin/nest_vars.sh
+COMPILER_FULL=$(nest-config --compiler)
+COMPILER_NAME=$(basename "${COMPILER_FULL}")
+
+sed -i "s!${COMPILER_FULL}!${CONDA_PREFIX}/bin/${COMPILER_NAME}!" "${PREFIX}/bin/nest-config"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,11 @@ requirements:
     - statsmodels
     - zlib
   run:
+    - c-compiler
+    - cxx-compiler
+    - make
+    - cmake
+    - zlib
     - boost
     - cython
     - gsl


### PR DESCRIPTION
This is a fix for #80. Compilers are now part of the runtime environment and paths are adapted according to the conda environment.